### PR TITLE
fix(): Codely light theme is not a dark theme

### DIFF
--- a/src/main/resources/codely_light.theme.json
+++ b/src/main/resources/codely_light.theme.json
@@ -1,6 +1,6 @@
 {
   "name": "Codely Light",
-  "dark": true,
+  "dark": false,
   "author": "CodelyTV",
   "editorScheme": "/codely_light.xml",
   "colors": {


### PR DESCRIPTION
Fix Codely Light theme metadata, so it can be detected as a light theme in Jetbrains 2020.3 IDE versions