### PR TITLE
fix: 🐛 whitespaces not being shown due to same color as bg

### DIFF
--- a/src/main/resources/codely_dark.xml
+++ b/src/main/resources/codely_dark.xml
@@ -79,8 +79,8 @@
     <option name="VCS_ANNOTATIONS_COLOR_4" value="5ca4a9" />
     <option name="VCS_ANNOTATIONS_COLOR_5" value="e6ebe0" />
     <option name="VISUAL_INDENT_GUIDE" value="303030" />
-    <option name="WHITESPACES" value="1e1e1e" />
     <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="86bac9" />
+    <option name="WHITESPACES" value="8c8888" />
   </colors>
   <attributes>
     <option name="ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES" baseAttributes="DEFAULT_METADATA" />


### PR DESCRIPTION
## Feature Motivation
Following your course "Exprimiendo IntelliJ", I was configuring the setting `show whitespaces` and realised that with the `Codely Dark Theme` the whitespaces color was the same as the background color. My color proposal is a light grey that is visible but not as light as other elements such as variables or comments. 

## Visual Result
### Before
![image](https://user-images.githubusercontent.com/19764148/104090868-cf74f080-5279-11eb-8c49-86ccd4a1072f.png)

### After
![image](https://user-images.githubusercontent.com/19764148/104090851-b53b1280-5279-11eb-84a2-b07d194c8414.png)
