### PR TITLE
Update builtin variable / builtin const for Go

### DIFF
--- a/src/main/resources/codely.xml
+++ b/src/main/resources/codely.xml
@@ -621,6 +621,7 @@
         <option name="FOREGROUND" value="458588" />
       </value>
     </option>
+    <option name="GO_BUILTIN_CONSTANT" baseAttributes="DEFAULT_CONSTANT" />
     <option name="GO_BUILTIN_FUNCTION_CALL">
       <value>
         <option name="FOREGROUND" value="fac149" />
@@ -635,6 +636,11 @@
     <option name="GO_EXPORTED_FUNCTION">
       <value>
         <option name="FOREGROUND" value="fac149" />
+      </value>
+    </option>
+    <option name="GO_BUILTIN_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="fb5245" />
       </value>
     </option>
     <option name="GO_EXPORTED_FUNCTION_CALL">

--- a/src/main/resources/codely_dark.xml
+++ b/src/main/resources/codely_dark.xml
@@ -632,6 +632,7 @@
         <option name="FOREGROUND" value="458588" />
       </value>
     </option>
+    <option name="GO_BUILTIN_CONSTANT" baseAttributes="DEFAULT_CONSTANT" />
     <option name="GO_BUILTIN_FUNCTION_CALL">
       <value>
         <option name="FOREGROUND" value="fac149" />
@@ -641,6 +642,12 @@
       <value>
         <option name="FOREGROUND" value="fac149" />
         <option name="FONT_TYPE" value="2" />
+      </value>
+    </option>
+    </option>
+    <option name="GO_BUILTIN_VARIABLE">
+      <value>
+        <option name="FOREGROUND" value="fb5245" />
       </value>
     </option>
     <option name="GO_EXPORTED_FUNCTION">


### PR DESCRIPTION
- Update GO_BUILTIN_CONSTANT to use the same color as DEFAULT_CONSTANT (use pink instead of brown that come from JetBrains's Darcula theme) (e.g. `true`, `false`)
- Update GO_BUILTIN_VARIABLE to use the same color as KEYWORD (red) (e.g. `nil`)

Screenshots:

![Screenshot](https://i.imgur.com/OZuKAQm.png)