### PR TITLE
#26: Fix codely and codely dark WHITESPACES themes

### DIFF
--- a/src/main/resources/codely.xml
+++ b/src/main/resources/codely.xml
@@ -78,7 +78,7 @@
     <option name="VCS_ANNOTATIONS_COLOR_4" value="5ca4a9" />
     <option name="VCS_ANNOTATIONS_COLOR_5" value="e6ebe0" />
     <option name="VISUAL_INDENT_GUIDE" value="303030" />
-    <option name="WHITESPACES" value="202124" />
+    <option name="WHITESPACES" value="716954" />
     <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="86bac9" />
     <option name="LINE_NUMBERS_COLOR" value="313337" />
   </colors>

--- a/src/main/resources/codely_dark.xml
+++ b/src/main/resources/codely_dark.xml
@@ -79,7 +79,7 @@
     <option name="VCS_ANNOTATIONS_COLOR_4" value="5ca4a9" />
     <option name="VCS_ANNOTATIONS_COLOR_5" value="e6ebe0" />
     <option name="VISUAL_INDENT_GUIDE" value="303030" />
-    <option name="WHITESPACES" value="1e1e1e" />
+    <option name="WHITESPACES" value="716954" />
     <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="86bac9" />
   </colors>
   <attributes>


### PR DESCRIPTION
Fix #26 

`codely.xml` and `codely_dark.xml` themes were using the background color for WHITESPACES