### PR TITLE
Fix whitespaces not showing in dark themes issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'tv.codely'
-version '2.2.0'
+version '2.2.1'
 
 sourceCompatibility = 1.8
 
@@ -32,6 +32,7 @@ patchPluginXml {
 
     changeNotes """
     <ul>
+    <li>2.2.1   Fix Dark theme's withspaces issue</li>
     <li>2.2.0   Add support to the experimental new ui</li>
     <li>2.1.6   Add support to 2022.2 IDEs</li>
     <li>2.1.5   Add support to 2022.1 IDEs</li>

--- a/src/main/resources/codely_blue.xml
+++ b/src/main/resources/codely_blue.xml
@@ -81,7 +81,7 @@
     <option name="VCS_ANNOTATIONS_COLOR_4" value="5ca4a9" />
     <option name="VCS_ANNOTATIONS_COLOR_5" value="e6ebe0" />
     <option name="VISUAL_INDENT_GUIDE" value="2a363e" />
-    <option name="WHITESPACES" value="1e2b32" />
+    <option name="WHITESPACES" value="65737e" />
     <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="1d363b" />
   </colors>
   <attributes>

--- a/src/main/resources/codely_dark.xml
+++ b/src/main/resources/codely_dark.xml
@@ -79,7 +79,7 @@
     <option name="VCS_ANNOTATIONS_COLOR_4" value="5ca4a9" />
     <option name="VCS_ANNOTATIONS_COLOR_5" value="e6ebe0" />
     <option name="VISUAL_INDENT_GUIDE" value="303030" />
-    <option name="WHITESPACES" value="1e1e1e" />
+    <option name="WHITESPACES" value="716954" />
     <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="86bac9" />
   </colors>
   <attributes>


### PR DESCRIPTION
This PR complete the mission requested(😂) in the PR #30 and fix the #26 issue for the Blue and Dark theme variants.

### Dark theme example image:
![image](https://user-images.githubusercontent.com/62360034/178042548-3d4eeb28-b2fe-4dea-8ed1-2705087ea909.png)

### Blue theme example image:
![image](https://user-images.githubusercontent.com/62360034/178043003-4cabfe4a-7d4e-47f4-b7d8-7b18cde79641.png)

Thanks! :) <💚>